### PR TITLE
Add an API with JSON response

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,77 @@
+# ebookmaker-web API
+
+This web interface to ebookmaker allows a more automation-friendly access
+through a simple HTML/JSON API. By including an `out` form field with value
+`json` in the POST, a JSON object is returned with structured access to the
+ebookmaker results.
+
+## Fields
+
+The API fields largely match the form on the web interface.
+
+Required parameters:
+* `out` - must be `json` to get a JSON response
+* `file` - uploaded file
+
+Optional parameters:
+* `ebook_number` - ebook number
+* `title` - title
+* `author` - author
+* `make_formats` - comma-separated ebookmaker formats to "make"
+  (will return most formats by default)
+* `validate_html` - controls if HTML uploads are validated before being
+  run through ebookmaker (defaults to False)
+* `debug_verbosity` - output DEBUG-level messages from ebookmaker
+  (defaults to False)
+
+## Example
+
+An example using python:
+```python
+import json
+import os.path
+
+import requests
+
+# file can be a txt, html, or zip file, just like the web version
+file = "/tmp/A_Thoughtles.html"
+
+with open(file, "rb") as fileobj:
+    response = requests.post(
+        "https://ebookmaker.pglaf.org/",
+        files={
+            # file to upload
+            "file": (os.path.basename(file), fileobj)
+        },
+        data={
+            # required params
+            "out": "json",
+            # optional params
+            "make_formats": "epub,epub3",  # comma-separated list
+            "validate_html": True,
+            "debug_verbosity": True,
+            "ebook_number": 99999,
+            "title": "Oh look, an egg!",
+            "author": "E. Bunny",
+        }
+    )
+
+    # response codes will either be 200 (everything ran successfully) or
+    # 500 (something went Very Wrong)
+    print(response.status_code)
+
+    # all responses are guaranteed to be JSON.
+    # error responses will contain an "error" field with more details
+    result = response.json()
+    print(json.dumps(result, indent=2))
+```
+
+Outputs the following:
+```json
+200
+{
+  "output_dir": "https://ebookmaker.pglaf.org/cache/20250412213215",
+  "output_log": "https://ebookmaker.pglaf.org/cache/20250412213215/output.txt",
+  "ebookmaker_log": "https://ebookmaker.pglaf.org/cache/20250412213215/ebookmaker.log"
+}
+```

--- a/index.php
+++ b/index.php
@@ -10,9 +10,32 @@
 
 ini_set('default_charset', 'UTF-8');
 
-set_exception_handler('exception_handler');
+// Get all user inputs.
+UserInputs::parse();
 
-output_header("Project Gutenberg Online Ebookmaker");
+// This script supports two modes: HTML & JSON.
+// When used in JSON mode all output written to stdout is captured and
+// dropped and we only return JSON to the requester -- on error and success.
+// This allows the code to interlace messages for a user visiting the web
+// without interfering with the JSON-only output we want in JSON mode.
+// This is a little kudgey but means we don't need to duplicate logic or
+// sprinkle if/else logic on mode everywhere.
+if (UserInputs::$output_format == "json") {
+    // capture all output to ensure that any errors that are surfaced
+    // don't interfere with our HTTP return code
+    ob_start();
+
+    // everything is a JSON response
+    header("Content-Type: application/json");
+
+    set_exception_handler('json_exception_handler');
+} else {
+    set_exception_handler('html_exception_handler');
+
+    output_header("Project Gutenberg Online Ebookmaker");
+}
+
+UserInputs::validate();
 
 // Load and validate configuration
 try {
@@ -31,9 +54,8 @@ try {
     throw new RuntimeException("ebookmaker web interface is misconfigured.");
 }
 
-
 // Main script
-if (! isset($_REQUEST['make'])) {
+if (! UserInputs::$make) {
     echo <<<EOPARA
     <h2>Quick Start</h2>
 
@@ -62,7 +84,7 @@ if (! isset($_REQUEST['make'])) {
     Missing metadata values are not usually a problem.</p>
 
     <p>After your file has transferred, processing can take as long
-    a few minutes for large files.</p>
+    as a few minutes for large files.</p>
 
     <h2>Usage Details</h2>
 
@@ -112,11 +134,6 @@ if (! isset($_REQUEST['make'])) {
     exit;
 }
 
-// Did we get input?
-if (!$_FILES['upfile1']['name']) {
-    throw new ValueError("Ebookmaker was requested to process files, but no file was received. Please try again, or send email for help.");
-}
-
 // Create new output directory:
 $tmpsubdir = date('YmdHis');
 $dirname = $tmpdir . "/" . $tmpsubdir;
@@ -128,7 +145,6 @@ if (!@mkdir($dirname)) {
 
 // We will redirect some messages to this file, for the user to read:
 $outfile = "$tmpdir/$tmpsubdir/output.txt";
-$ebookmaker_log = "$tmpdir/$tmpsubdir/ebookmaker.log";
 
 // Put a BOM at the start (it should always be UTF-8) (temporarily open as a stream):
 $bom = (chr(0xEF) . chr(0xBB) . chr(0xBF));
@@ -161,119 +177,19 @@ if (!$basename) {
 
 append_output_log("\nInput file: $basename\n");
 
-##### Figure out HTML version if needed, and generate output for user:
-$not_html5 = 0;
-if (str_ends_with($basename, ".html") || str_ends_with($basename, ".htm")) {
-    # Did we get HTML5? Look at the first line:
-    $tmpin = fopen($basename, "r");
-    if ($tmpin == false) {
-        throw new RuntimeException("Error opening file $basename for validation.");
-    }
-    $line = fgets($tmpin);
-    $regex = '/<\!DOCTYPE html/i';
-    if (! preg_match($regex, $line)) {
-        $not_html5 = 1;
-    }
-    # We also need to look for xhtml in the doctype line:
-    $regex = '/xhtml/i';
-    if (preg_match($regex, $line)) {
-        $not_html5 = 1;
-    }
-    fclose($tmpin);
+if (UserInputs::$validate_html) {
+    validate_html($basename);
+}
 
-    # We got HTML5. Validate it:
-    if ($not_html5 == 0) {
-        print "<p style='color: green'>Validating your uploaded file...</p>";
-        append_output_log("Validating your uploaded file");
-        # TODO: what should we do if the validator fails? Log it? Error out?
-        $args = [
-            $validator,  # trusted input
-            escapeshellarg($basename),
-            ">>",
-            escapeshellarg($outfile),
-            "2>&1",
-        ];
-        system(join(" ", $args), $retval);
-        append_output_log("Validation complete");
+[$retval, $ebookmaker_log] = run_ebookmaker($basename, "$tmpdir/$tmpsubdir", $outfile);
+
+if (UserInputs::$output_format == "json") {
+    if ($retval) {
+        throw new RuntimeException("Error running ebookmaker. See output.txt for more information.");
+    } else {
+        return_json_response("$mybaseurl/cache/$tmpsubdir", $ebookmaker_log);
     }
 }
-
-if ($not_html5 || str_ends_with($basename, "xhtml")) {
-    echo <<<EOPARA
-    <p style='color: blue'>Your HTML does not seem to be HTML version
-    5. Be sure to run the appropriate validator, probably the W3C's
-    <a href="https://validator.w3.org">legacy HTML &amp; CSS
-    validator</a>.</p>
-    EOPARA;
-
-    append_output_log("--- HTML validation not done");
-    append_output_log("HTML validation not done since your source is not HTML5.");
-    append_output_log("You must use a validator such as https://validator.w3.org in addition to ebookmaker");
-    append_output_log("---");
-}
-
-// Options to ebookmaker:
-$opts = [
-    "--make", "txt.utf-8",
-    "--make", "epub",
-    "--make", "epub3",
-    "--make", "kf8",
-    "--make", "kindle",
-    "--make", "html",
-    "--validate",
-    "--max-depth", 3,
-    "--output-dir", "$tmpdir/$tmpsubdir",
-];
-
-# required argument
-$opts[] = "--ebook";
-if (strlen($_REQUEST['myebook'])) {
-    $opts[] = escapeshellarg($_REQUEST['myebook']);
-} else {
-    $opts[] = 10001; # Required
-}
-if (strlen($_REQUEST['mytitle'])) {
-    $opts[] = "--title";
-    $opts[] = escapeshellarg($_REQUEST['mytitle']);
-}
-if (strlen($_REQUEST['myauthor'])) {
-    $opts[] = "--author";
-    $opts[] = escapeshellarg($_REQUEST['myauthor']);
-}
-
-$gopts = join(" ", $opts);
-
-// Run ebookmaker
-print "<p><span style='color: green'>Running ebookmaker</span>: ";
-print "<tt>ebookmaker $gopts file://$basename\n</tt>\n";
-print "</p>";
-
-append_output_log("\n");
-append_output_log("--- Starting ebookmaker processing");
-$args = [
-    $prog,  # trusted input
-    "--version",
-    ">>",
-    escapeshellarg($outfile),
-];
-system(join(" ", $args), $retval);
-if ($retval) {
-    // if we can't run a basic --version something is very wrong and we should stop
-    throw new RuntimeException("Error running ebookmaker version check.");
-}
-append_output_log("Command: ebookmaker $gopts file://$basename");
-$args = [
-    $prog,  # trusted input
-    $gopts,  # pre-escaped inputs
-    escapeshellarg("file://$basename"),
-    ">>",
-    escapeshellarg($ebookmaker_log),
-    "2>&1",
-];
-system(join(" ", $args), $retval);
-// put the contents of the ebookmaker.log file into output.txt
-file_put_contents($outfile, file_get_contents($ebookmaker_log), FILE_APPEND);
-append_output_log("--- ebookmaker complete");
 
 if (!$retval) {
     print "<p><span style='color: green'>Done</span>: ebookmaker has completed. This does not mean all desired output was successfully generated.  The output.txt file provides detail on the processing that occurred, and any error or informational messages.\n";
@@ -299,16 +215,75 @@ print "<p><a href=\"?\">Return to main page</a></p>\n";
 
 //----------------------------------------------------------------------------
 
+class UserInputs
+{
+    public static ?string $ebook_number;
+    public static ?string $title;
+    public static ?string $author;
+    public static ?string $file_field_name;
+    public static array $make_formats;
+    public static string $output_format = "html";
+    public static bool $validate_html = false;
+    public static bool $debug_verbosity = false;
+    public static bool $make = false;
+
+    public static function parse(): void
+    {
+        // Note: these $_POST and $_FILES key names are part of the API
+        // and should not be changed without care. See API.md
+        UserInputs::$ebook_number = $_POST['ebook_number'] ?? $_POST['myebook'] ?? null;
+        UserInputs::$title = $_POST['title'] ?? $_POST['mytitle'] ?? null;
+        UserInputs::$author = $_POST['author'] ?? $_POST['myauthor'] ?? null;
+        UserInputs::$file_field_name = null;
+        foreach (['file', 'upfile1'] as $field_name) {
+            if (isset($_FILES[$field_name])) {
+                UserInputs::$file_field_name = $field_name;
+                break;
+            }
+        }
+
+        if (isset($_POST["make_formats"])) {
+            UserInputs::$make_formats = explode(",", $_POST["make_formats"]);
+        } else {
+            UserInputs::$make_formats = [
+                "txt.utf-8", "epub", "epub3", "kf8", "kindle", "html",
+            ];
+        }
+
+        UserInputs::$output_format = $_POST["out"] ?? "html";
+        if (!in_array(UserInputs::$output_format, ["html", "json"])) {
+            UserInputs::$output_format = "html";
+        }
+
+        if (isset($_POST["validate_html"])) {
+            UserInputs::$validate_html = filter_var($_POST["validate_html"], FILTER_VALIDATE_BOOL);
+        }
+
+        if (isset($_POST["debug_verbosity"])) {
+            UserInputs::$debug_verbosity = filter_var($_POST["debug_verbosity"], FILTER_VALIDATE_BOOL);
+        }
+
+        UserInputs::$make = isset($_POST["make"]) || UserInputs::$output_format == "json";
+    }
+
+    public static function validate(): void
+    {
+        if (UserInputs::$make && !UserInputs::$file_field_name) {
+            throw new ValueError("Ebookmaker was requested to process files, but no file was received. Please try again, or send email for help.");
+        }
+    }
+}
+
 function do_form(): void
 {
     echo <<<EOFORM
     <blockquote>
     <form enctype="multipart/form-data" method="POST" accept-charset="UTF-8">
-    <input type="file" name="upfile1" required> Your file (any of: zip/txt/htm/html)
-    <br><input type="text" size="50" name="mytitle" placeholder="Title"> eBook title
-    <br><input type="text" size="50" name="myauthor" placeholder="Author"> eBook author
-    <!-- <br><input type="text" size="20" name="myencoding" value=""> File encoding (us-ascii, iso-8859-1, utf-8, etc.; mandatory for plain text files) -->
-    <br><input type="number" size="10" name="myebook" placeholder="10001"> eBook number (must be an integer)
+    <input type="hidden" name="validate_html" value="true">
+    <input type="file" name="file" required> Your file (any of: zip/txt/htm/html)
+    <br><input type="text" size="50" name="title" placeholder="Title"> eBook title
+    <br><input type="text" size="50" name="author" placeholder="Author"> eBook author
+    <br><input type="number" size="10" name="ebook_number" placeholder="10001"> eBook number (must be an integer)
 
     <br><input type="submit" value="Make it!" name="make">
     </form>
@@ -345,9 +320,14 @@ function output_footer(): void
     production or status questions.
     </p>
 
+    <p>This online tool can return a well-structured JSON response from a form
+    POST by including the field "out" with value "json". This is useful for
+    running ebookmaker from automation. See <a href="API.md">API.md</a> for
+    more details.</p>
+
     <p>The ebookmaker software is available as a free download,
     if you would rather run it on your own system.
-    You can find the software for download here: <a href="https://github.com/gutenbergtools/ebookmaker">https://github.com/gutenbergtools/ebookmaker</a></p>
+    You can find the software for download at <a href="https://github.com/gutenbergtools/ebookmaker">https://github.com/gutenbergtools/ebookmaker</a></p>
 
     </body>
     </html>
@@ -384,14 +364,12 @@ function append_output_log(string $message): void
 
 function process_uploaded_file(string $dirname): void
 {
-    $formname = "upfile1";
-
     // Rename uploaded file
-    $upfile1_name = fix_filename($_FILES[$formname]['name']);
+    $upfile1_name = fix_filename($_FILES[UserInputs::$file_field_name]['name']);
     $newname = $dirname . "/" . $upfile1_name;
 
     // remove from php spool area
-    if (!@rename($_FILES[$formname]['tmp_name'], $newname)) {
+    if (!@rename($_FILES[UserInputs::$file_field_name]['tmp_name'], $newname)) {
         throw new RuntimeException("Error renaming uploaded file");
     }
     if (!@chmod($newname, 0644)) {
@@ -464,7 +442,177 @@ function locate_file_for_ebookmaker(string $dirname): string
     return $basename;
 }
 
-function exception_handler($exception): void
+function validate_html($basename)
+{
+    global $validator, $outfile;
+
+    ##### Figure out HTML version if needed, and generate output for user:
+    $not_html5 = 0;
+    if (str_ends_with($basename, ".html") || str_ends_with($basename, ".htm")) {
+        # Did we get HTML5? Look at the first line:
+        $tmpin = fopen($basename, "r");
+        if ($tmpin == false) {
+            throw new RuntimeException("Error opening file $basename for validation.");
+        }
+        $line = fgets($tmpin);
+        $regex = '/<\!DOCTYPE html/i';
+        if (! preg_match($regex, $line)) {
+            $not_html5 = 1;
+        }
+        # We also need to look for xhtml in the doctype line:
+        $regex = '/xhtml/i';
+        if (preg_match($regex, $line)) {
+            $not_html5 = 1;
+        }
+        fclose($tmpin);
+
+        # We got HTML5. Validate it:
+        if ($not_html5 == 0) {
+            print "<p style='color: green'>Validating your uploaded file...</p>";
+            append_output_log("Validating your uploaded file");
+            # TODO: what should we do if the validator fails? Log it? Error out?
+            $args = [
+                $validator,  # trusted input
+                escapeshellarg($basename),
+                ">>",
+                escapeshellarg($outfile),
+                "2>&1",
+            ];
+            system(join(" ", $args), $retval);
+            append_output_log("Validation complete");
+        }
+    }
+
+    if ($not_html5 || str_ends_with($basename, "xhtml")) {
+        echo <<<EOPARA
+        <p style='color: blue'>Your HTML does not seem to be HTML version
+        5. Be sure to run the appropriate validator, probably the W3C's
+        <a href="https://validator.w3.org">legacy HTML &amp; CSS
+        validator</a>.</p>
+        EOPARA;
+
+        append_output_log("--- HTML validation not done");
+        append_output_log("HTML validation not done since your source is not HTML5.");
+        append_output_log("You must use a validator such as https://validator.w3.org in addition to ebookmaker");
+        append_output_log("---");
+    }
+}
+
+function run_ebookmaker(
+    string $input_path,
+    string $output_dir,
+    string $logfile
+): array {
+    global $prog;
+
+    $ebookmaker_log = "$output_dir/ebookmaker.log";
+
+    // Options to ebookmaker:
+    $opts = [
+        "--verbose",
+        "--validate",
+        "--max-depth", 3,
+        "--output-dir", $output_dir,
+    ];
+
+    // a second --verbose will give DEBUG-level messages
+    if (UserInputs::$debug_verbosity) {
+        $opts[] = "--verbose";
+    }
+
+    foreach (UserInputs::$make_formats as $format) {
+        $opts[] = "--make";
+        $opts[] = escapeshellarg(trim($format));
+    }
+
+    # required argument
+    $opts[] = "--ebook";
+    if (UserInputs::$ebook_number) {
+        $opts[] = escapeshellarg(UserInputs::$ebook_number);
+    } else {
+        $opts[] = 10001; # Required
+    }
+    if (UserInputs::$title) {
+        $opts[] = "--title";
+        $opts[] = escapeshellarg(UserInputs::$title);
+    }
+    if (UserInputs::$author) {
+        $opts[] = "--author";
+        $opts[] = escapeshellarg(UserInputs::$author);
+    }
+
+    $gopts = join(" ", $opts);
+
+    // Run ebookmaker
+    print "<p><span style='color: green'>Running ebookmaker</span>: ";
+    print "<tt>ebookmaker $gopts file://$input_path\n</tt>\n";
+    print "</p>";
+
+    append_output_log("\n");
+    append_output_log("--- Starting ebookmaker processing");
+    system("$prog --version >> $logfile", $retval);
+    if ($retval) {
+        // if we can't run a basic --version something is very wrong and we should stop
+        throw new RuntimeException("Error running ebookmaker version check.");
+    }
+    append_output_log("Command: ebookmaker $gopts file://$input_path");
+    $args = [
+        $prog,  # trusted input
+        $gopts,  # pre-escaped inputs
+        escapeshellarg("file://$input_path"),
+        ">>",
+        escapeshellarg($ebookmaker_log),
+        "2>&1",
+    ];
+    system(join(" ", $args), $retval);
+    // put the contents of the ebookmaker.log file into output.txt
+    file_put_contents($logfile, file_get_contents($ebookmaker_log), FILE_APPEND);
+    append_output_log("--- ebookmaker complete");
+
+    return [$retval, $ebookmaker_log];
+}
+
+function output_json_response(string $data, int $response_code = 200)
+{
+    // drop the output buffer we've been storing to prevent errant output
+    // from violating the JSON response
+    ob_end_clean();
+
+    http_response_code($response_code);
+    echo $data;
+    exit();
+}
+
+function return_json_response(string $url_basedir, string $ebookmaker_log): void
+{
+    # TODO: parse ebookmaker_log file for details
+
+    // NOT: data in this dictionary should be considered an API and changed
+    // with care!
+    $data = [
+        "output_dir" => $url_basedir,
+        "output_log" => "$url_basedir/output.txt",
+        "ebookmaker_log" => "$url_basedir/ebookmaker.log",
+    ];
+    $response = json_encode(
+        $data,
+        JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES
+    );
+    output_json_response($response, 200);
+}
+
+function json_exception_handler($exception): void
+{
+    $response = json_encode(
+        ["error" => $exception->getMessage()],
+        JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES
+    );
+    output_json_response($response, 500);
+
+    append_output_log("JSON interface encountered an exception: " . $exception->getMessage());
+}
+
+function html_exception_handler($exception): void
 {
     echo "<p style='color: red'>\n";
     echo htmlspecialchars($exception->getMessage(), ENT_QUOTES, 'UTF-8');

--- a/index.php
+++ b/index.php
@@ -128,6 +128,7 @@ if (!@mkdir($dirname)) {
 
 // We will redirect some messages to this file, for the user to read:
 $outfile = "$tmpdir/$tmpsubdir/output.txt";
+$ebookmaker_log = "$tmpdir/$tmpsubdir/ebookmaker.log";
 
 // Put a BOM at the start (it should always be UTF-8) (temporarily open as a stream):
 $bom = (chr(0xEF) . chr(0xBB) . chr(0xBF));
@@ -266,10 +267,12 @@ $args = [
     $gopts,  # pre-escaped inputs
     escapeshellarg("file://$basename"),
     ">>",
-    escapeshellarg($outfile),
+    escapeshellarg($ebookmaker_log),
     "2>&1",
 ];
 system(join(" ", $args), $retval);
+// put the contents of the ebookmaker.log file into output.txt
+file_put_contents($outfile, file_get_contents($ebookmaker_log), FILE_APPEND);
 append_output_log("--- ebookmaker complete");
 
 if (!$retval) {


### PR DESCRIPTION
This PR adds an "API" to ebookmaker-web, allowing well-formed JSON responses to form POSTs. This allows programmatic access from things like Guiguts. There should be zero functional changes to the inputs or outputs of the web version with this PR.

From the script:
```php
// This script supports two modes: HTML & JSON.
// When used in JSON mode all output written to stdout is captured and
// dropped and we only return JSON to the requester -- on error and success.
// This allows the code to interlace messages for a user visiting the web
// without interfering with the JSON-only output we want in JSON mode.
// This is a little kudgey but means we don't need to duplicate logic or
// sprinkle if/else logic on mode everywhere.
```

This is currently available for testing at https://ebookmaker.pglaf.org/dev/

I'm going to add some inline comments to the file and would appreciate feedback. 

_This should not be merged until we've resolved these inline comments._