### PR TITLE
Return URLS to the output artifacts in API

### DIFF
--- a/API.md
+++ b/API.md
@@ -72,6 +72,11 @@ Outputs the following:
 {
   "output_dir": "https://ebookmaker.pglaf.org/cache/20250412213215",
   "output_log": "https://ebookmaker.pglaf.org/cache/20250412213215/output.txt",
-  "ebookmaker_log": "https://ebookmaker.pglaf.org/cache/20250412213215/ebookmaker.log"
+  "ebookmaker_log": "https://ebookmaker.pglaf.org/cache/20250412213215/ebookmaker.log",
+  "output_artifacts": {
+    "epub.noimages": "https://ebookmaker.pglaf.org/cache/20250412213215/99999-epub.epub",
+    "epub.images": "https://ebookmaker.pglaf.org/cache/20250412213215/99999-images-epub.epub",
+    "epub3.images": "https://ebookmaker.pglaf.org/cache/20250412213215/99999-images-epub3.epub"
+  }
 }
 ```


### PR DESCRIPTION
Now that https://github.com/gutenbergtools/ebookmaker/pull/269 is in we can return direct links in the API response to the artifacts generated by the ebookmaker. Should make things marginally easier for GG2.

This still requires the user to know they asked for `epub3` and the artifact is named `epub3.images` but I don't want to hide too much because that becomes fragile.

Example:
```json
{
  "output_dir": "https://ebookmaker.pglaf.org/cache/20250521180809",
  "output_log": "https://ebookmaker.pglaf.org/cache/20250521180809/output.txt",
  "ebookmaker_log": "https://ebookmaker.pglaf.org/cache/20250521180809/ebookmaker.log",
  "output_artifacts": {
    "epub.noimages": "https://ebookmaker.pglaf.org/cache/20250521180809/99999-epub.epub",
    "epub.images": "https://ebookmaker.pglaf.org/cache/20250521180809/99999-images-epub.epub",
    "epub3.images": "https://ebookmaker.pglaf.org/cache/20250521180809/99999-images-epub3.epub"
  }
}
```